### PR TITLE
added slight UI treatment to active footnote

### DIFF
--- a/site/_includes/styles/components/_article.scss
+++ b/site/_includes/styles/components/_article.scss
@@ -747,6 +747,11 @@
       text-decoration: none;
       transition: all var(--transition);
    }
+   
+   .footnote-item:target {
+      outline: 1px dotted;
+      background-color: var(--blue-6);
+   }
 
    .feed-only {
       display: none;


### PR DESCRIPTION
I found when reading your long blog-posts, clicking the footnotes was very helpful.

Added a slight UI treatment to highlight the currently targeted footnote, when clicking through a footnote reference link.

## Screenshot

![Screen Shot 2022-03-24 at 12 50 45 PM](https://user-images.githubusercontent.com/51207/159968959-a5ce144d-fc69-4725-be3f-39855d7faa41.png)

